### PR TITLE
Fix invalid chord in [PL] uri ri ura

### DIFF
--- a/app/src/main/res/raw-pl/uri_uri_ura
+++ b/app/src/main/res/raw-pl/uri_uri_ura
@@ -31,7 +31,7 @@ BGCOLOR="#FFFFFF" TEXT="#000000" LINK="#800000" VLINK="#004000" ALINK="#CF3060">
 </FONT><FONT COLOR="#A13F3C">                    e
 </FONT><FONT COLOR="#000000">     dziecina malusieńka.
 
-</FONT><FONT COLOR="#A13F3C">                         S7
+</FONT><FONT COLOR="#A13F3C">                         H7
 </FONT><FONT COLOR="#000000">W.   Dziecina maleńka narodzi się,                    
 </FONT><FONT COLOR="#A13F3C">                    e
 </FONT><FONT COLOR="#000000">     dziecina malusieńka.


### PR DESCRIPTION
I've notices a typo in Polish translation of "Uri Uri Ura". There was "S7" instead of "H7".